### PR TITLE
setup.sh: Remove helper functions once done with installation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -44,7 +44,7 @@ function do_install() {
   pull_easyengine_images
   add_ssl_renew_cron
   ee_log_info1 "Run \"ee help site\" for more information on how to create a site."
-  rm -rf /helper-functions
+  rm /helper-functions
 }
 
 # Invoking the main installation function.

--- a/setup.sh
+++ b/setup.sh
@@ -44,6 +44,7 @@ function do_install() {
   pull_easyengine_images
   add_ssl_renew_cron
   ee_log_info1 "Run \"ee help site\" for more information on how to create a site."
+  rm -rf /helper-functions
 }
 
 # Invoking the main installation function.


### PR DESCRIPTION
As seen in line 18 and 37. The helper function is being used. But then it is being left as residue after that (Even uninstall script does not remove it.) So we need to remove it after installation.

Ref : https://github.com/EasyEngine/easyengine/pull/1847