### PR TITLE
fix: replace apt with apt-get and consolidate apt-get update

### DIFF
--- a/functions
+++ b/functions
@@ -233,7 +233,7 @@ function setup_php_extensions() {
   if command -v php >/dev/null 2>&1; then
     php_extensions=(curl sqlite3 zip)
     if ! command -v gawk >/dev/null 2>&1; then
-      apt install gawk -y
+      apt-get install gawk -y
     fi
     # Reading the php version.
     default_php_version="$(readlink -f /usr/bin/php | gawk -F "php" '{ print $2}')"
@@ -247,8 +247,10 @@ function setup_php_extensions() {
       else
         ee_log_info1 "$module is already installed"
       fi
-      apt install -y $packages
     done
+    if [ -n "$packages" ]; then
+      apt-get install -y $packages
+    fi
   fi
 }
 
@@ -275,17 +277,24 @@ function check_swap() {
 function setup_host_dependencies() {
     if [ "$EE_LINUX_DISTRO" == "Ubuntu" ] || [ "$EE_LINUX_DISTRO" == "Debian" ]; then
       if ! command -v ip >> $LOG_FILE 2>&1; then
-        echo "Installing iproute2"
-        apt update && apt install iproute2 -y
+        ee_log_info2 "Installing iproute2"
+        apt-get install iproute2 -y
       fi
     fi
 }
 
 function check_depdendencies() {
   ee_log_info1 "Checking dependencies"
+
+  # Run apt update once upfront so that all subsequent apt install calls
+  # can find their packages.  On a freshly booted machine the apt cache
+  # is typically empty and installs would fail without this.
+  ee_log_info2 "Updating apt cache"
+  apt-get update
+
   if ! command -v sqlite3 >/dev/null 2>&1; then
     ee_log_info2 "Installing sqlite3"
-    apt install sqlite3 -y
+    apt-get install sqlite3 -y
   fi
 
   setup_host_dependencies

--- a/setup.sh
+++ b/setup.sh
@@ -19,7 +19,7 @@ function bootstrap() {
     if ! command -v wget > /dev/null 2>&1; then
       packages="${packages} wget"
     fi
-    apt update && apt-get install $packages -y
+    apt-get update && apt-get install $packages -y
   fi
 
   local functions_url="https://raw.githubusercontent.com/EasyEngine/installer/master/functions"


### PR DESCRIPTION
## Summary

Replaces all bare `apt` calls with `apt-get` throughout `functions` and `setup.sh`, and consolidates the package cache refresh into a single upfront `apt-get update` call.

## Problem

The installer mixed `apt` and `apt-get` across multiple functions. `apt` is designed for interactive terminal use — its CLI interface is explicitly unstable and emits warnings in non-interactive/scripted contexts. Scripts should always use `apt-get`.

Additionally, `apt-get update` was scattered across multiple functions (called individually before each package install), causing redundant cache refreshes. On freshly booted machines with an empty apt cache, any function that didn't call `update` first would fail.

There was also a bug in `setup_php_extensions()` where `apt-get install $packages` was called inside the per-module loop, triggering a no-op install on every iteration for already-installed modules.

## Changes

### `setup.sh`
- `apt update` → `apt-get update` in `bootstrap()`

### `functions`
- `apt install gawk` → `apt-get install gawk` in `setup_php_extensions()`
- Move `apt-get install $packages` **outside** the per-module loop, guarded with `[ -n "$packages" ]` — avoids no-op installs on every iteration and only installs when there are actually missing modules
- `setup_host_dependencies()`: `apt update && apt install iproute2` → `apt-get install iproute2`; the redundant per-install `apt update` is dropped because the cache is now refreshed once upfront
- `check_depdendencies()`: add a single upfront `apt-get update` before any package installs; replace raw `echo` with `ee_log_info2` for the iproute2 message
- `apt install sqlite3` → `apt-get install sqlite3`

## Testing

- [x] Fresh Ubuntu install
- [x] Fresh Debian install