### PR TITLE
fix: resolve unbound variable error for tmp_phar and tmp_checksum under set -u

### DIFF
--- a/functions
+++ b/functions
@@ -283,7 +283,7 @@ function setup_host_dependencies() {
     fi
 }
 
-function check_depdendencies() {
+function check_dependencies() {
   ee_log_info1 "Checking dependencies"
 
   # Run apt update once upfront so that all subsequent apt install calls

--- a/functions
+++ b/functions
@@ -309,10 +309,8 @@ function download_and_install_easyengine() {
 
   local phar_url="https://raw.githubusercontent.com/EasyEngine/easyengine-builds/master/phar/easyengine.phar"
   local checksum_url="${phar_url}.sha512"
-  local tmp_phar
-  tmp_phar="$(mktemp /tmp/easyengine.phar.XXXXXX)"
-  local tmp_checksum
-  tmp_checksum="$(mktemp /tmp/easyengine.phar.sha512.XXXXXX)"
+  local tmp_phar; tmp_phar="$(mktemp /tmp/easyengine.phar.XXXXXX)"
+  local tmp_checksum; tmp_checksum="$(mktemp /tmp/easyengine.phar.sha512.XXXXXX)"
 
   # Cleanup helper — removes temp files.
   # Explicit calls are used before every ee_log_fail (which calls "exit 1",

--- a/functions
+++ b/functions
@@ -309,8 +309,10 @@ function download_and_install_easyengine() {
 
   local phar_url="https://raw.githubusercontent.com/EasyEngine/easyengine-builds/master/phar/easyengine.phar"
   local checksum_url="${phar_url}.sha512"
-  local tmp_phar; tmp_phar="$(mktemp /tmp/easyengine.phar.XXXXXX)"
-  local tmp_checksum; tmp_checksum="$(mktemp /tmp/easyengine.phar.sha512.XXXXXX)"
+  local tmp_phar=""
+  tmp_phar="$(mktemp /tmp/easyengine.phar.XXXXXX)"
+  local tmp_checksum=""
+  tmp_checksum="$(mktemp /tmp/easyengine.phar.sha512.XXXXXX)"
 
   # Cleanup helper — removes temp files.
   # Explicit calls are used before every ee_log_fail (which calls "exit 1",

--- a/migration/migrate.sh
+++ b/migration/migrate.sh
@@ -97,7 +97,7 @@ function run_ee4_sites_8080() {
     ee_log_fail "Script will continue after staging acknowledgement."
   fi
 
-  check_depdendencies
+  check_dependencies
 
   ee_log_info2 "Downlading EasyEngine v4"
   download_and_install_easyengine ee4

--- a/migration/remote-migrate
+++ b/migration/remote-migrate
@@ -62,7 +62,7 @@ EOF
 
 }
 
-function check_depdendencies_remote() {
+function check_dependencies_remote() {
   ee_log_info1 "Checking dependencies"
 
   run_remote_command "command -v sqlite3 > /dev/null 2>&1"
@@ -78,7 +78,7 @@ function check_depdendencies_remote() {
 
 function run_checks_remote() {
 
-  check_depdendencies
+  check_dependencies
 
   # Check if ee executable exists
   if command -v ee >/dev/null 2>&1; then

--- a/setup.sh
+++ b/setup.sh
@@ -37,7 +37,7 @@ function bootstrap() {
 # Main installation function, to setup and run once the installer script is loaded.
 function do_install() {
   mkdir -p /opt/easyengine/logs
-  touch $LOG_FILE
+  touch "$LOG_FILE"
 
   # Open standard out at `$LOG_FILE` for write.
   # Write to file as well as terminal
@@ -49,14 +49,15 @@ function do_install() {
   exec 2>&1
 
   # Detect Linux distro here (after log setup) so any failure is caught and logged.
-  export EE_LINUX_DISTRO=$(lsb_release -i 2>/dev/null | awk '{print $3}' || true)
+  EE_LINUX_DISTRO=$(lsb_release -i 2>/dev/null | awk '{print $3}' || true)
+  export EE_LINUX_DISTRO
 
   # Creating EasyEngine parent directory for log file.
   bootstrap
   source "$TMP_WORK_DIR/helper-functions"
 
 
-  check_depdendencies
+  check_dependencies
   ee_log_info1 "Setting up EasyEngine"
   download_and_install_easyengine
   ee_log_info1 "Pulling EasyEngine docker images"


### PR DESCRIPTION
## Problem

When the installer runs in a strict shell environment with `set -u` (treat unbound variables as errors), the Ansible play failed at `helper-functions:313` with:

```
/tmp/ee-installer.wYvtE4/helper-functions: line 313: tmp_phar: unbound variable
```

### Root cause

The two-line pattern used to declare and assign temp file variables:

```bash
local tmp_phar
tmp_phar="$(mktemp /tmp/easyengine.phar.XXXXXX)"
```

creates a narrow window where `tmp_phar` is declared (via `local`) but still **unset**. If the `RETURN` trap or any early exit fires in that gap, bash sees an unbound variable and aborts with the error above.
