### PR TITLE
fix: run apt non-interactively during installation

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -8,6 +8,11 @@ export LOG_FILE="$EE_ROOT_DIR/logs/install.log"
 # "unbound variable" errors when the sourced functions file checks it.
 export EE_QUIET_OUTPUT="${EE_QUIET_OUTPUT:-}"
 
+# Run apt/dpkg non-interactively so package installation never blocks on a
+# debconf or needrestart prompt during an unattended setup.
+export DEBIAN_FRONTEND=noninteractive
+export NEEDRESTART_MODE=a
+
 # Create a temp directory for downloaded helper files and clean it on exit.
 TMP_WORK_DIR="$(mktemp -d /tmp/ee-installer.XXXXXX)"
 export TMP_WORK_DIR


### PR DESCRIPTION
## What

Set `DEBIAN_FRONTEND=noninteractive` and `NEEDRESTART_MODE=a` at the top of `setup.sh` so every `apt-get` call in the installer — and in the sourced `functions` — runs without prompting.

## Why

Unattended installs (cloud-init, CI, config-management tooling) can stall when apt or `needrestart` tries to open an interactive prompt and there's no TTY to answer it. Setting the non-interactive frontend up front keeps package installation fully headless.

## Notes

- Exports live in `setup.sh` so they apply before `bootstrap()` and propagate to the sourced `functions`, covering all package installs in one place.
- No behavioural change for interactive installs.