### PR TITLE
fix: clean up downloaded helper scripts after install

### DIFF
--- a/functions
+++ b/functions
@@ -185,9 +185,10 @@ function setup_docker() {
   ee_log_info1 "Installing Docker"
   # Check if docker exists. If not start docker installation.
   if ! command -v docker >/dev/null 2>&1; then
-    # Running standard docker installation.
-    wget --quiet get.docker.com -O docker-setup.sh
-    sh docker-setup.sh
+    # Download into TMP_WORK_DIR so setup.sh's EXIT trap cleans it up on any
+    # exit path, instead of leaving docker-setup.sh behind in the CWD.
+    wget --quiet get.docker.com -O "$TMP_WORK_DIR/docker-setup"
+    sh "$TMP_WORK_DIR/docker-setup"
   fi
 
   # Check if docker-compose exists. If not start docker-compose installation.

--- a/setup.sh
+++ b/setup.sh
@@ -18,6 +18,16 @@ TMP_WORK_DIR="$(mktemp -d /tmp/ee-installer.XXXXXX)"
 export TMP_WORK_DIR
 trap 'rm -rf "$TMP_WORK_DIR"' EXIT
 
+# Remember this script's path so it can delete itself after a successful
+# install (the `ee` from `wget -qO ee https://rt.cx/ee4 && bash ee`). Only when
+# run directly: BASH_SOURCE[0] equals $0 when executed, differs when sourced
+# (e.g. remote-migrate), and is empty when piped (`curl ... | bash`). Resolve
+# to an absolute path so a later `cd` can't strand it. EE_KEEP_INSTALLER=1 opts out.
+INSTALLER_SELF=""
+if [ -z "${EE_KEEP_INSTALLER:-}" ] && [ "${BASH_SOURCE[0]:-}" = "$0" ] && [ -f "${BASH_SOURCE[0]}" ]; then
+  INSTALLER_SELF="$(cd "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)/$(basename -- "${BASH_SOURCE[0]}")"
+fi
+
 function bootstrap() {
   if ! command -v curl > /dev/null 2>&1; then
     packages="curl"
@@ -80,3 +90,9 @@ function do_install() {
 
 # Invoking the main installation function.
 do_install
+
+# Reached only on success (set -e exits earlier on failure, leaving the file
+# for a retry). Remove the downloaded installer so it doesn't linger.
+if [ -n "$INSTALLER_SELF" ] && [ -f "$INSTALLER_SELF" ]; then
+  rm -f "$INSTALLER_SELF" || true
+fi


### PR DESCRIPTION
Closes #15.

After a successful install the installer left two downloaded helper scripts on disk. This cleans both up.

### `ee` installer script
The canonical install (`wget -qO ee https://rt.cx/ee4 && sudo bash ee`) leaves the `ee` file in the user's working directory. `setup.sh` now removes itself once the install succeeds.

Guards:
- **Self-deletes only when executed directly** — `BASH_SOURCE[0]` equals `$0` when the script is run with `bash ee`, differs when it is *sourced* (e.g. `remote-migrate` sources the installer over SSH), and is empty when piped (`curl ... | bash`). So sourced and piped runs delete nothing. Using `BASH_SOURCE[0]` instead of `$0` also avoids the pipe case wrongly matching a file literally named `bash` in the current directory.
- **Absolute path** resolved at capture time, so a later `cd` can't leave it behind.
- **Opt-out** via `EE_KEEP_INSTALLER=1` (useful when running a checkout in place).
- Runs only on the success path; on failure `set -e` exits earlier and the file is left for a retry.

### `docker-setup.sh`
`setup_docker()` downloaded `get.docker.com` to `docker-setup.sh` in the current directory and never removed it. It now downloads into `TMP_WORK_DIR`, so the existing `EXIT` trap in `setup.sh` cleans it up on every exit path — including download/install failures.

### Testing
Verified in an `ubuntu:24.04` container (bash 5.2.21):
- `bash ee` → removes itself; `curl | bash` → removes nothing (even with a `bash` file in CWD); sourced run → file kept; `EE_KEEP_INSTALLER=1` → kept; `cd` before delete → still removes the right file.
- Docker helper cleaned up on both success and simulated failure paths; no `docker-setup.sh` left in CWD.
